### PR TITLE
Added _sass directory and _includes

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm"
+        crossorigin="anonymous">
+    <link rel="stylesheet" href="/css/main.css">
+    <title>Document</title>
+</head>

--- a/_layouts/aboutme.html
+++ b/_layouts/aboutme.html
@@ -1,16 +1,4 @@
-<!DOCTYPE html>
-<html lang="en">
-
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm"
-        crossorigin="anonymous">
-    <link rel="stylesheet" href="/_site/assets/main.css">
-    <title>Document</title>
-</head>
-
+{% include header.html %}
 <body>
     <div class="header" id="header">
         <div class="navigation">

--- a/_sass/_typography.scss
+++ b/_sass/_typography.scss
@@ -1,0 +1,23 @@
+// This is a partial.
+// It lies in <source>/_sass, just waiting to be imported.
+// It does not contain the YAML front matter and has no corresponding output file in the built site.
+
+body {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 18px;
+  line-height: 1.5;
+  color: #24292e;
+  background-color: #fff;
+}
+
+a {
+  color: #0366d6;
+}
+
+code,
+pre {
+  font-family: Menlo, Consolas, "Consolas for Powerline", "Courier New", Courier, monospace;
+  background-color: #2b2b2b;
+  color: #fff;
+  padding: 0.25em
+}

--- a/css/main.scss
+++ b/css/main.scss
@@ -1,0 +1,13 @@
+---
+# this ensures Jekyll reads the file to be transformed into CSS later
+# only Main files contain this front matter, not partials.
+---
+
+@import "typography";
+body {
+  background-color: pink;
+}
+.content {
+  width: 45rem;
+  margin: 0 auto;
+}


### PR DESCRIPTION
I added a _sass directory that holds all your partial sass files, these get imported in the `/css/main.scss` directory (you can dump all your css in the main.scss or organise them into partials in the `_sass` directory, then import them into main).

The content in `/css` will get generated to `_site/css` so in your header I included 
`<link rel="stylesheet" href="/css/main.css">`
As an example I made the body pink.

I also created a `_includes` directory, this is where you place your reusable elements e.g. the header.html is used on each page. 
I created a header.html include and added it to your aboutme.html as an example.
Use `{% include header.html %}` to add anything in the _includes directory to you layouts.

